### PR TITLE
feat: add support for pop templates

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -52,6 +52,39 @@ jobs:
             binary_path: target/release/evm-template-node
             rust_version: nightly-2024-06-12
             omni_node_support: false
+          - name: pop-standard
+            repo: https://github.com/r0gue-io/base-parachain.git
+            ref: polkadot-stable2412
+            folder: base-parachain
+            wasm_path: target/release/wbuild/parachain-template-runtime/parachain_template_runtime.compact.compressed.wasm
+            binary_path: target/release/parachain-template-node
+            rust_version: nightly-2024-09-04
+            omni_node_support: false
+          - name: pop-assets
+            repo: https://github.com/r0gue-io/assets-parachain.git
+            ref: polkadot-stable2412
+            folder: assets-parachain
+            wasm_path: target/release/wbuild/parachain-template-runtime/parachain_template_runtime.compact.compressed.wasm
+            binary_path: target/release/parachain-template-node
+            rust_version: nightly-2024-10-15
+            omni_node_support: false
+          - name: pop-contracts
+            repo: https://github.com/r0gue-io/contracts-parachain.git 
+            ref: polkadot-stable2409
+            folder: contracts-parachain
+            wasm_path: target/release/wbuild/parachain-template-runtime/parachain_template_runtime.compact.compressed.wasm
+            binary_path: target/release/parachain-template-node
+            rust_version: nightly-2024-09-04
+            omni_node_support: false
+          - name: pop-evm
+            repo: https://github.com/r0gue-io/evm-parachain.git
+            ref: polkadot-stable2407
+            folder: evm-parachain
+            wasm_path: target/release/wbuild/parachain-template-runtime/parachain_template_runtime.compact.compressed.wasm
+            binary_path: target/release/parachain-template-node
+            rust_version: nightly-2024-04-09
+            omni_node_support: false
+
     steps:
     - name: Install shared dependencies (Linux)
       if: matrix.os == 'parity-large'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -167,7 +167,7 @@ jobs:
         cd ${{ matrix.template.folder }}
         echo "Current directory: $(pwd)"
         echo "Directory contents:"
-        cargo build --release
+        cargo build --production
         echo "Build completed."
 
     - name: Post-build Cache Debug Info

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 Pre-Building different parachain templates
-| Name                  | Repository                                                               | Reference | Rust Version       |
-|-----------------------|--------------------------------------------------------------------------|-----------|--------------------|
-| polkadot-sdk-parachain| https://github.com/paritytech/polkadot-sdk-parachain-template.git#master | master    | nightly-2024-09-11 |
-| frontier              | https://github.com/polkadot-evm/frontier.git                             | master    | nightly-2024-02-05 |
-| openzeppelin-generic  | https://github.com/OpenZeppelin/polkadot-runtime-templates.git           | v2.0.1    | nightly-2024-06-12 |
-| openzeppelin-evm      | https://github.com/OpenZeppelin/polkadot-runtime-templates.git           | v2.0.1    | nightly-2024-06-12 |
+| Name                  | Repository                                                               | Reference          | Rust Version       |
+|-----------------------|--------------------------------------------------------------------------|--------------------|--------------------|
+| polkadot-sdk-parachain| https://github.com/paritytech/polkadot-sdk-parachain-template.git#master | master             | nightly-2024-09-11 |
+| frontier              | https://github.com/polkadot-evm/frontier.git                             | master             | nightly-2024-02-05 |
+| openzeppelin-generic  | https://github.com/OpenZeppelin/polkadot-runtime-templates.git           | v2.0.1             | nightly-2024-06-12 |
+| openzeppelin-evm      | https://github.com/OpenZeppelin/polkadot-runtime-templates.git           | v2.0.1             | nightly-2024-06-12 |
+| pop-standard          | https://github.com/r0gue-io/base-parachain.git                           | polkadot-stable2412| nightly-2024-09-04 |
+| pop-assets            | https://github.com/r0gue-io/assets-parachain.git                         | polkadot-stable2412| nightly-2024-10-15 |
+| pop-contracts         | https://github.com/r0gue-io/contracts-parachain.git                      | polkadot-stable2409| nightly-2024-09-04 |
+| pop-evm               | https://github.com/r0gue-io/evm-parachain.git                            | polkadot-stable2407| nightly-2024-04-09 |


### PR DESCRIPTION
This PR introduces support for pop templates

- https://github.com/r0gue-io/base-parachain
- https://github.com/r0gue-io/assets-parachain
- https://github.com/r0gue-io/contracts-parachain
- https://github.com/r0gue-io/evm-parachain

If needed, we can adjust the process to pull the binaries directly from releases, e.g: https://github.com/r0gue-io/assets-parachain/releases/tag/polkadot-stable2412
